### PR TITLE
Add: meeting notes for the kickoff of the comm-comm WG

### DIFF
--- a/meeting-notes/01-20December2018.md
+++ b/meeting-notes/01-20December2018.md
@@ -1,0 +1,31 @@
+# dat protocol Community communication 
+
+20 Dec 2018
+
+## People
+
+* Martin Heidegger (@martinheidegger)
+* Franz K.H. (@Frando)
+* Diego Paez (@dpaez)
+
+## Agenda
+
+* Introduce the comm-comm WG, discuss goals. 
+
+## Meeting Notes
+
+* @martinheidegger introduce himself. He is a freelancer developer. He is using Dat in a project where they are managing petabytes of data. They've evaluated data center costs (among other variables)  and decided to move forward using Dat for such a job. 
+* @martinheidegger also mention he have contributed with different projects on the Dat ecosystem. One of these is Dat-desktop.
+* @Frando introduce himself. He is a freelance developer currently working on a decentralized media project where they are dealing with short-lived resources using Dat. They have created an app similar to Dat-desktop called [archipel](https://github.com/archipel-somoco/archipel) with multiwriter support. He is also working on a modhle called [hyperlib](https://github.com/Frando/hyperlib) where he is exploring the concept of _mounts_ in Dat.
+* @dpaez introduces himself, he is representing [GEUT](https://github.com/geut) a new JS company where they are looking to explore new products powered by Dat. He also mention that they were running a [Dat workshop](https://github.com/geut/dat-workshop) recently at NodeconfAr and at local meetups events.
+* There was interest in greater the use of DAT in a web application context.
+
+## Decisions Made
+
+* Maintain a weekly comm-comm meeting.
+* Promote this space as a place where the community (individuals or companies) can tell how they are using Dat.
+* Improve userland modules discoverability. This could give more visibility to existing projects that others could find usefull and/or even become contributors.
+
+## ACTION ITEMS
+
+* Create a repo to showcase existing dat projects, modules, apps, services, etc.


### PR DESCRIPTION
This PR adds the new `/meeting-notes` directory along with the notes of the 1st comm-comm meeting 🎉 